### PR TITLE
Add support for additional claims

### DIFF
--- a/esaco-app/src/test/java/it/infn/mw/esaco/test/TokenInfoControllerTests.java
+++ b/esaco-app/src/test/java/it/infn/mw/esaco/test/TokenInfoControllerTests.java
@@ -144,11 +144,21 @@ public class TokenInfoControllerTests extends EsacoTestUtils {
     assertThat(introspection.getClientId(), equalTo(CLIENT_ID));
     assertThat(introspection.getTokenType(), equalTo(TOKEN_TYPE));
     assertThat(introspection.getOrganisationName(), not(isEmptyOrNullString()));
+    assertThat(introspection.getGroupNames(), isA(String[].class));
+    assertThat(introspection.getGroupNames(), not(emptyArray()));
+    assertThat(introspection.getEduPersonEntitlements(), isA(String[].class));
+    assertThat(introspection.getEduPersonEntitlements(), not(emptyArray()));
+    assertThat(introspection.getAcr(), not(isEmptyOrNullString()));
 
     assertThat(userinfo.getPreferredUsername(), equalTo(USERNAME));
     assertThat(userinfo.getGroups(), isA(String[].class));
     assertThat(userinfo.getGroups(), not(emptyArray()));
     assertThat(userinfo.getOrganisationName(), not(isEmptyOrNullString()));
+    assertThat(userinfo.getGroupNames(), isA(String[].class));
+    assertThat(userinfo.getGroupNames(), not(emptyArray()));
+    assertThat(userinfo.getEduPersonEntitlements(), isA(String[].class));
+    assertThat(userinfo.getEduPersonEntitlements(), not(emptyArray()));
+    assertThat(userinfo.getAcr(), not(isEmptyOrNullString()));
   }
 
   @Test

--- a/esaco-app/src/test/java/it/infn/mw/esaco/test/TokenInfoServiceTests.java
+++ b/esaco-app/src/test/java/it/infn/mw/esaco/test/TokenInfoServiceTests.java
@@ -94,6 +94,11 @@ public class TokenInfoServiceTests extends EsacoTestUtils {
     assertThat(introspection.getClientId(), equalTo(CLIENT_ID));
     assertThat(introspection.getTokenType(), equalTo(TOKEN_TYPE));
     assertThat(introspection.getOrganisationName(), not(isEmptyOrNullString()));
+    assertThat(introspection.getGroupNames(), isA(String[].class));
+    assertThat(introspection.getGroupNames(), not(emptyArray()));
+    assertThat(introspection.getEduPersonEntitlements(), isA(String[].class));
+    assertThat(introspection.getEduPersonEntitlements(), not(emptyArray()));
+    assertThat(introspection.getAcr(), not(isEmptyOrNullString()));
   }
 
   @Test
@@ -107,6 +112,11 @@ public class TokenInfoServiceTests extends EsacoTestUtils {
     assertThat(userinfo.getGroups(), isA(String[].class));
     assertThat(userinfo.getGroups(), not(emptyArray()));
     assertThat(userinfo.getOrganisationName(), not(isEmptyOrNullString()));
+    assertThat(userinfo.getGroupNames(), isA(String[].class));
+    assertThat(userinfo.getGroupNames(), not(emptyArray()));
+    assertThat(userinfo.getEduPersonEntitlements(), isA(String[].class));
+    assertThat(userinfo.getEduPersonEntitlements(), not(emptyArray()));
+    assertThat(userinfo.getAcr(), not(isEmptyOrNullString()));
   }
 
   @Test(expected = HttpConnectionException.class)

--- a/esaco-app/src/test/java/it/infn/mw/esaco/test/utils/EsacoTestUtils.java
+++ b/esaco-app/src/test/java/it/infn/mw/esaco/test/utils/EsacoTestUtils.java
@@ -43,6 +43,9 @@ public class EsacoTestUtils {
     .organisationName("indigo-dc")
     .name("Admin User")
     .email("admin@example.org")
+    .groupNames(new String[] {"Production", "Analysis"})
+    .eduPersonEntitlements(new String[] {"urn:mace:egi.eu:group:vo.test.egi.eu:role=member#aai.egi.eu"})
+    .acr("https://aai.egi.eu/LoA#Substantial")
     .build();
 
   protected final IamUser VALID_USERINFO = IamUser.getBuilder()
@@ -56,6 +59,9 @@ public class EsacoTestUtils {
     .updatedAt("Mon Sep 04 15:08:36 CEST 2017")
     .groups(new String[] {"Production", "Analysis"})
     .organisationName("indigo-dc")
+    .groupNames(new String[] {"Production", "Analysis"})
+    .eduPersonEntitlements(new String[] {"urn:mace:egi.eu:group:vo.test.egi.eu:role=member#aai.egi.eu"})
+    .acr("https://aai.egi.eu/LoA#Substantial")
     .build();
 
   protected final IamIntrospection EXPIRED_INTROSPECTION =

--- a/esaco-common/src/main/java/it/infn/mw/esaco/model/IamIntrospection.java
+++ b/esaco-common/src/main/java/it/infn/mw/esaco/model/IamIntrospection.java
@@ -29,6 +29,9 @@ public class IamIntrospection {
   private final String organisationName;
   private final String name;
   private final String email;
+  private final String[] groupNames;
+  private final String[] eduPersonEntitlements;
+  private final String acr;
 
   @JsonCreator
   public IamIntrospection(@JsonProperty("active") boolean active,
@@ -39,7 +42,10 @@ public class IamIntrospection {
       @JsonProperty("preferred_username") String preferredUsername,
       @JsonProperty("organisation_name") String organisationName,
       @JsonProperty("name") String name,
-      @JsonProperty("email") String email) {
+      @JsonProperty("email") String email,
+      @JsonProperty("groupNames") String[] groupNames,
+      @JsonProperty("edu_person_entitlements") String[] eduPersonEntitlements,
+      @JsonProperty("acr") String acr) {
 
     this.active = active;
     this.scope = scope;
@@ -55,6 +61,9 @@ public class IamIntrospection {
     this.organisationName = organisationName;
     this.name = name;
     this.email = email;
+    this.groupNames = groupNames;
+    this.eduPersonEntitlements = eduPersonEntitlements;
+    this.acr = acr;
   }
 
   public IamIntrospection(IamIntrospectionBuilder builder) {
@@ -72,6 +81,9 @@ public class IamIntrospection {
     this.organisationName = builder.organisationName;
     this.name = builder.name;
     this.email = builder.email;
+    this.groupNames = builder.groupNames;
+    this.eduPersonEntitlements = builder.eduPersonEntitlements;
+    this.acr = builder.acr;
   }
 
   public static IamIntrospectionBuilder getBuilder() {
@@ -102,62 +114,79 @@ public class IamIntrospection {
     return exp;
   }
 
-  
+
   public String getIss() {
     return iss;
   }
-  
-  
+
+
   public String getSub() {
 
     return sub;
   }
 
-  
+
   public String getUserId() {
 
     return userId;
   }
 
-  
+
   public String getClientId() {
 
     return clientId;
   }
 
-  
+
   public String getTokenType() {
 
     return tokenType;
   }
 
-  
+
   public String[] getGroups() {
 
     return groups;
   }
 
-  
+
   public String getPreferredUsername() {
 
     return preferredUsername;
   }
-  
-  
+
+
   public String getOrganisationName() {
 
     return organisationName;
   }
-  
-  
+
+
   public String getName() {
     return name;
   }
 
-  
+
   public String getEmail() {
     return email;
   }
+
+
+  @JsonProperty("groupNames")
+  public String[] getGroupNames() {
+    return groupNames;
+  }
+
+
+  public String[] getEduPersonEntitlements() {
+    return eduPersonEntitlements;
+  }
+
+
+  public String getAcr() {
+    return acr;
+  }
+
 
   @Generated("auto-generated method")
   @Override
@@ -178,6 +207,9 @@ public class IamIntrospection {
     result = prime * result + ((sub == null) ? 0 : sub.hashCode());
     result = prime * result + ((tokenType == null) ? 0 : tokenType.hashCode());
     result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+    result = prime * result + Arrays.hashCode(groupNames);
+    result = prime * result + Arrays.hashCode(eduPersonEntitlements);
+    result = prime * result + ((acr == null) ? 0 : acr.hashCode());
     return result;
   }
 
@@ -255,9 +287,18 @@ public class IamIntrospection {
         return false;
     } else if (!userId.equals(other.userId))
       return false;
+    if (!Arrays.equals(groupNames, other.groupNames))
+      return false;
+    if (!Arrays.equals(eduPersonEntitlements, other.eduPersonEntitlements))
+      return false;
+    if (acr == null) {
+      if (other.acr != null)
+        return false;
+    } else if (!acr.equals(other.acr))
+      return false;
     return true;
   }
 
-  
+
 
 }

--- a/esaco-common/src/main/java/it/infn/mw/esaco/model/IamIntrospectionBuilder.java
+++ b/esaco-common/src/main/java/it/infn/mw/esaco/model/IamIntrospectionBuilder.java
@@ -15,6 +15,9 @@ public class IamIntrospectionBuilder {
   String organisationName;
   String name;
   String email;
+  String[] groupNames;
+  String[] eduPersonEntitlements;
+  String acr;
 
   public IamIntrospectionBuilder isActive(boolean active) {
     this.active = active;
@@ -40,7 +43,7 @@ public class IamIntrospectionBuilder {
     this.iss = iss;
     return this;
   }
-  
+
   public IamIntrospectionBuilder sub(String sub) {
     this.sub = sub;
     return this;
@@ -80,12 +83,27 @@ public class IamIntrospectionBuilder {
     this.name = name;
     return this;
   }
-  
+
   public IamIntrospectionBuilder email(String email) {
     this.email = email;
     return this;
   }
-  
+
+  public IamIntrospectionBuilder groupNames(String[] groupNames) {
+    this.groupNames = groupNames;
+    return this;
+  }
+
+  public IamIntrospectionBuilder eduPersonEntitlements(String[] eduPersonEntitlements) {
+    this.eduPersonEntitlements = eduPersonEntitlements;
+    return this;
+  }
+
+  public IamIntrospectionBuilder acr(String acr) {
+    this.acr = acr;
+    return this;
+  }
+
   public IamIntrospection build() {
     return new IamIntrospection(this);
   }

--- a/esaco-common/src/main/java/it/infn/mw/esaco/model/IamUser.java
+++ b/esaco-common/src/main/java/it/infn/mw/esaco/model/IamUser.java
@@ -37,6 +37,9 @@ public class IamUser {
   private final String birthdate;
   private final String[] groups;
   private final String organisationName;
+  private final String[] groupNames;
+  private final String[] eduPersonEntitlements;
+  private final String acr;
 
   @JsonCreator
   public IamUser(@JsonProperty("sub") String sub, @JsonProperty("name") String name,
@@ -51,7 +54,10 @@ public class IamUser {
       @JsonProperty("phone_number_verified") Boolean phoneNumberVerified,
       @JsonProperty("address") String address, @JsonProperty("updated_at") String updatedAt,
       @JsonProperty("birthdate") String birthdate, @JsonProperty("groups") String[] groups,
-      @JsonProperty("organisation_name") String organisationName) {
+      @JsonProperty("organisation_name") String organisationName,
+      @JsonProperty("groupNames") String[] groupNames,
+      @JsonProperty("edu_person_entitlements") String[] eduPersonEntitlements,
+      @JsonProperty("acr") String acr) {
 
     this.sub = sub;
     this.name = name;
@@ -75,6 +81,9 @@ public class IamUser {
     this.birthdate = birthdate;
     this.groups = groups;
     this.organisationName = organisationName;
+    this.groupNames = groupNames;
+    this.eduPersonEntitlements = eduPersonEntitlements;
+    this.acr = acr;
   }
 
   public IamUser(IamUserBuilder builder) {
@@ -100,37 +109,40 @@ public class IamUser {
     this.birthdate = builder.birthdate;
     this.groups = builder.groups;
     this.organisationName = builder.organisationName;
+    this.groupNames = builder.groupNames;
+    this.eduPersonEntitlements = builder.eduPersonEntitlements;
+    this.acr = builder.acr;
   }
 
   public static IamUserBuilder getBuilder() {
     return new IamUserBuilder();
   }
 
-  
+
   public String getSub() {
 
     return sub;
   }
 
-  
+
   public String getPreferredUsername() {
 
     return preferredUsername;
   }
 
-  
+
   public String getName() {
 
     return name;
   }
-  
-  
+
+
   public String getGivenName() {
 
     return givenName;
   }
-  
-  
+
+
   public String getFamilyName() {
 
     return familyName;
@@ -221,6 +233,22 @@ public class IamUser {
     return organisationName;
   }
 
+  @JsonProperty("groupNames")
+  public String[] getGroupNames() {
+
+    return groupNames;
+  }
+
+  public String[] getEduPersonEntitlements() {
+
+    return eduPersonEntitlements;
+  }
+
+  public String getAcr() {
+
+    return acr;
+  }
+
   @Override
   @Generated("auto-generated method")
   public int hashCode() {
@@ -249,6 +277,9 @@ public class IamUser {
     result = prime * result + ((updatedAt == null) ? 0 : updatedAt.hashCode());
     result = prime * result + ((website == null) ? 0 : website.hashCode());
     result = prime * result + ((zoneinfo == null) ? 0 : zoneinfo.hashCode());
+    result = prime * result + Arrays.hashCode(groupNames);
+    result = prime * result + Arrays.hashCode(eduPersonEntitlements);
+    result = prime * result + ((acr == null) ? 0 : acr.hashCode());
     return result;
   }
 
@@ -369,6 +400,15 @@ public class IamUser {
       if (other.zoneinfo != null)
         return false;
     } else if (!zoneinfo.equals(other.zoneinfo))
+      return false;
+    if (!Arrays.equals(groupNames, other.groupNames))
+      return false;
+    if (!Arrays.equals(eduPersonEntitlements, other.eduPersonEntitlements))
+      return false;
+    if (acr == null) {
+      if (other.acr != null)
+        return false;
+    } else if (!acr.equals(other.acr))
       return false;
     return true;
   }

--- a/esaco-common/src/main/java/it/infn/mw/esaco/model/IamUserBuilder.java
+++ b/esaco-common/src/main/java/it/infn/mw/esaco/model/IamUserBuilder.java
@@ -23,6 +23,9 @@ public class IamUserBuilder {
   String birthdate;
   String[] groups;
   String organisationName;
+  String[] groupNames;
+  String[] eduPersonEntitlements;
+  String acr;
 
   public IamUserBuilder sub(String sub) {
     this.sub = sub;
@@ -131,6 +134,21 @@ public class IamUserBuilder {
 
   public IamUserBuilder organisationName(String organisationName) {
     this.organisationName = organisationName;
+    return this;
+  }
+
+  public IamUserBuilder groupNames(String[] groupNames) {
+    this.groupNames = groupNames;
+    return this;
+  }
+
+  public IamUserBuilder eduPersonEntitlements(String[] eduPersonEntitlements) {
+    this.eduPersonEntitlements = eduPersonEntitlements;
+    return this;
+  }
+
+  public IamUserBuilder acr(String acr) {
+    this.acr = acr;
     return this;
   }
 


### PR DESCRIPTION
Some introspection endpoints provide extra claims in responses. These
need to be passed down to the client using ESACO as an introspection
proxy.

For details, see https://wiki.egi.eu/wiki/AAI_guide_for_SPs#Claims-based_authorisation

Added claims:
- `acr`, used by EGI AAI
- `edu_person_entitlements`, used by EGI AAI
- `groupNames`, used by MUNI AAI (semantics similar to `edu_person_entitlements`)

This is an optional extension, it will not have an impact on introspection endpoints
not providing extra claims.