### PR TITLE
Add maven build workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,53 @@
+#
+# Copyright (c) Istituto Nazionale di Fisica Nucleare (INFN). 2016-2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build image
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Docker login
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Docker metainformation for esaco
+      id: ls-meta
+      uses: docker/metadata-action@v5
+      with:
+        images: indigoiam/esaco
+        tags: |
+          type=sha
+          type=ref,event=tag
+          type=ref,event=branch
+    - name: Build & push esaco docker image
+      uses: docker/build-push-action@v6
+      with:
+        tags: ${{ steps.ls-meta.outputs.tags }}
+        labels: ${{ steps.ls-meta.outputs.labels }}
+        context: .
+        # Uncomment if Dockerfile FROM changes
+        #platforms: linux/amd64,linux/arm64
+        push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,39 +18,25 @@ name: Maven build
 
 on:
   push:
-    branches: '*'
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Docker login
-      uses: docker/login-action@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: Docker metainformation for esaco
-      id: ls-meta
-      uses: docker/metadata-action@v5
+        distribution: 'temurin'
+        java-version: 21
+    - name: Cache Maven packages
+      uses: actions/cache@v4
       with:
-        images: indigoiam/esaco
-        tags: |
-          type=sha
-          type=ref,event=tag
-          type=ref,event=branch
-    - name: Build & push esaco docker image
-      uses: docker/build-push-action@v6
-      with:
-        tags: ${{ steps.ls-meta.outputs.tags }}
-        labels: ${{ steps.ls-meta.outputs.labels }}
-        context: .
-        # Uncomment if Dockerfile FROM changes
-        #platforms: linux/amd64,linux/arm64
-        push: ${{ startsWith(github.ref, 'refs/tags/') }}
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Build with Maven
+      run: mvn -B clean package
+    - name: Checkstyle with Maven
+      run: mvn clean compile -U -Dmaven.test.failure.ignore -DfailIfNoTests=false checkstyle:check -Dcheckstyle.config.location=google_checks.xml


### PR DESCRIPTION
Current Maven build workflow was dedicated to building the Docker Image.
This PR renames the current "Maven Build" flow and replaces it with a proper one, building the Java Spring Boot app with JDK 21.