### PR TITLE
Retrieve introspect endpoint from well-known response

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,45 @@
+name: Sonar analysis
+
+on:
+  push:
+    branches:
+      - develop
+
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java-version: [21]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK ${{matrix.java-version}}
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        cache: maven
+        java-version: ${{matrix.java-version}}
+
+    - name: Sonar analysis
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_VIANELLO }}
+      run: mvn -B -U verify sonar:sonar
+            -Dsonar.projectKey=indigo-iam_esaco 
+            -Dsonar.organization=indigo-iam 
+            -Dsonar.login=$SONAR_TOKEN
+            -Dsonar.pullrequest.key=${{ github.event.number }}
+            -Dsonar.pullrequest.branch=${{ github.HEAD_REF }}
+            -Dsonar.pullrequest.base=${{ github.BASE_REF }}
+            -Dsonar.pullrequest.github.repository=${{ github.repository }}
+            -Dsonar.scm.provider=git
+            -Dsonar.host.url=https://sonarcloud.io

--- a/esaco-app/pom.xml
+++ b/esaco-app/pom.xml
@@ -124,19 +124,12 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
         <executions>
           <execution>
-            <id>default-prepare-agent</id>
+            <id>jacoco-site-aggregate</id>
+            <phase>verify</phase>
             <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
+              <goal>report-aggregate</goal>
             </goals>
           </execution>
         </executions>

--- a/esaco-app/src/main/java/it/infn/mw/esaco/EsacoConfiguration.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/EsacoConfiguration.java
@@ -56,7 +56,7 @@ import it.infn.mw.esaco.util.x509.X509BlindTrustManager;
 public class EsacoConfiguration {
 
   // 0 means no timeout
-  private static final int TRUST_ANCHORS_BUNDLE_CONNECTION_TIMEOUT_CA_MSEC = 0; 
+  private static final int TRUST_ANCHORS_BUNDLE_CONNECTION_TIMEOUT_CA_MSEC = 0;
 
   @Bean
   X509CertChainValidatorExt certificateValidator(X509TrustProperties x509Properties) {
@@ -164,13 +164,13 @@ public class EsacoConfiguration {
 
   @Bean
   ClientHttpRequestFactory httpRequestFactory(X509TrustProperties x509Properties,
-      TlsProperties tlsProperties) throws Exception {
+      TlsProperties tlsProperties) {
     return new HttpComponentsClientHttpRequestFactory(httpClient(x509Properties, tlsProperties));
   }
 
   @Bean
-  RestTemplate defaultRestTemplate(X509TrustProperties x509Properties, TlsProperties tlsProperties)
-      throws Exception {
+  RestTemplate defaultRestTemplate(X509TrustProperties x509Properties,
+      TlsProperties tlsProperties) {
     return new RestTemplate(httpRequestFactory(x509Properties, tlsProperties));
   }
 

--- a/esaco-app/src/main/java/it/infn/mw/esaco/EsacoConfiguration.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/EsacoConfiguration.java
@@ -142,8 +142,7 @@ public class EsacoConfiguration {
   }
 
   @Bean
-  HttpClient httpClient(X509TrustProperties x509Properties, TlsProperties tlsProperties)
-      throws Exception {
+  HttpClient httpClient(X509TrustProperties x509Properties, TlsProperties tlsProperties) {
     DefaultClientTlsStrategy sslSocketFactory =
         new DefaultClientTlsStrategy(sslContext(x509Properties, tlsProperties));
 

--- a/esaco-app/src/main/java/it/infn/mw/esaco/config/DelegatingOpaqueTokenIntrospector.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/config/DelegatingOpaqueTokenIntrospector.java
@@ -1,15 +1,22 @@
 package it.infn.mw.esaco.config;
 
 import java.text.ParseException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTParser;
 
 import it.infn.mw.esaco.OidcClient;
@@ -19,29 +26,24 @@ import it.infn.mw.esaco.exception.UnsupportedIssuerException;
 
 public class DelegatingOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 
-  private final Map<String, OpaqueTokenIntrospector> introspectors;
+  private final OidcClientProperties properties;
+  private final Function<OidcClient, RestTemplate> restTemplateFactory;
+  private final Map<String, OpaqueTokenIntrospector> cache = new ConcurrentHashMap<>();
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   public DelegatingOpaqueTokenIntrospector(OidcClientProperties properties,
       Function<OidcClient, RestTemplate> restTemplateFactory) {
-    this.introspectors =
-        properties.getClients()
-          .stream()
-          .collect(
-              Collectors
-                .toMap(OidcClient::getIssuerUrl,
-                    client -> new SpringOpaqueTokenIntrospector(
-                        client.getIssuerUrl() + "/introspect", restTemplateFactory.apply(client)),
-                    (existing, replacement) -> existing));
+
+    this.properties = properties;
+    this.restTemplateFactory = restTemplateFactory;
   }
 
   @Override
   public OAuth2AuthenticatedPrincipal introspect(String token) {
+
     String issuer = getIssuerFromAccessToken(token);
-    OpaqueTokenIntrospector introspector = introspectors.get(issuer);
-    if (introspector == null) {
-      throw new UnsupportedIssuerException("No introspector for issuer: " + issuer);
-    }
-    return introspector.introspect(token);
+    return cache.computeIfAbsent(issuer, this::createIntrospectorForIssuer).introspect(token);
   }
 
   private String getIssuerFromAccessToken(String accessToken) {
@@ -50,5 +52,53 @@ public class DelegatingOpaqueTokenIntrospector implements OpaqueTokenIntrospecto
     } catch (ParseException e) {
       throw new TokenValidationException("Error reading issuer claim from access token", e);
     }
+  }
+
+  private OpaqueTokenIntrospector createIntrospectorForIssuer(String issuer) {
+
+    OidcClient client = properties.getClients().stream()
+        .filter(c -> issuer.equals(c.getIssuerUrl()))
+        .findFirst()
+        .orElseThrow(() -> new UnsupportedIssuerException("Unsupported issuer: " + issuer));
+
+    RestTemplate restTemplate = restTemplateFactory.apply(client);
+    String introspectionEndpoint = resolveIntrospectionEndpoint(issuer, restTemplate);
+
+    return new SpringOpaqueTokenIntrospector(introspectionEndpoint, restTemplate);
+  }
+
+  /**
+   * Discover the introspection_endpoint from the issuer's discovery document.
+   * Tries OpenID Connect discovery first, then OAuth Authorization Server discovery.
+   */
+  private String resolveIntrospectionEndpoint(String issuerUrl, RestTemplate restTemplate) {
+
+    // ensure issuerUrl does not end with a trailing slash
+    String base = issuerUrl.endsWith("/") ? issuerUrl.substring(0, issuerUrl.length() - 1) : issuerUrl;
+
+    // candidate discovery endpoints (OIDC first, then oauth-authorization-server)
+    List<String> discoveryUrls = Arrays.asList(
+        base + "/.well-known/openid-configuration",
+        base + "/.well-known/oauth-authorization-server"
+    );
+
+    for (String discoveryUrl : discoveryUrls) {
+      try {
+        ResponseEntity<String> resp = restTemplate.getForEntity(discoveryUrl, String.class);
+        if (resp.getStatusCode() != HttpStatus.OK || resp.getBody() == null) {
+          continue;
+        }
+        JsonNode doc = objectMapper.readTree(resp.getBody());
+        JsonNode introspectNode = doc.get("introspection_endpoint");
+        if (introspectNode != null && introspectNode.isTextual()) {
+          return introspectNode.asText();
+        }
+      } catch (RestClientException | java.io.IOException e) {
+        // ignore this discovery URL and try the next; we'll throw later if none work
+      }
+    }
+
+    throw new IllegalStateException(
+        "Unable to discover introspection_endpoint for issuer: " + issuerUrl);
   }
 }

--- a/esaco-app/src/main/java/it/infn/mw/esaco/service/impl/DefaultTokenInfoService.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/service/impl/DefaultTokenInfoService.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -28,14 +27,17 @@ public class DefaultTokenInfoService implements TokenInfoService {
 
   public static final Logger LOGGER = LoggerFactory.getLogger(DefaultTokenInfoService.class);
 
-  @Autowired
   private ObjectMapper mapper;
-
-  @Autowired
   private TokenIntrospectionService tokenIntrospectionService;
-
-  @Autowired
   private TimeProvider timeProvider;
+
+  public DefaultTokenInfoService(TimeProvider timeProvider,
+      TokenIntrospectionService tokenIntrospectionService, ObjectMapper mapper) {
+
+    this.timeProvider = timeProvider;
+    this.tokenIntrospectionService = tokenIntrospectionService;
+    this.mapper = mapper;
+  }
 
   @Override
   public AccessToken parseJWTAccessToken(String jwtAccessToken) {

--- a/esaco-app/src/main/java/it/infn/mw/esaco/service/impl/DefaultTokenInfoService.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/service/impl/DefaultTokenInfoService.java
@@ -81,7 +81,6 @@ public class DefaultTokenInfoService implements TokenInfoService {
   @Cacheable("userinfo")
   public IamUser decodeUserInfo(String accessToken) {
 
-    IamUser info = null;
     Optional<String> response = tokenIntrospectionService.getUserInfoForToken(accessToken);
 
     if (response.isPresent()) {
@@ -92,10 +91,8 @@ public class DefaultTokenInfoService implements TokenInfoService {
         LOGGER.error(msg, e);
         throw new TokenIntrospectionException(msg, e);
       }
-    } else {
-      LOGGER.info("No userinfo data available for access token '{}'", accessToken);
     }
-    return info;
+    return null;
   }
 
   @Override

--- a/esaco-app/src/main/java/it/infn/mw/esaco/service/impl/SpringTokenIntrospectionAdapter.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/service/impl/SpringTokenIntrospectionAdapter.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -32,14 +31,17 @@ public class SpringTokenIntrospectionAdapter implements TokenIntrospectionServic
   public static final Logger LOGGER =
       LoggerFactory.getLogger(SpringTokenIntrospectionAdapter.class);
 
-  @Autowired
   private OpaqueTokenIntrospector introspector;
-
-  @Autowired
   private ObjectMapper objectMapper;
-
-  @Autowired
   private RestTemplate restTemplate;
+
+  public SpringTokenIntrospectionAdapter(OpaqueTokenIntrospector introspector,
+      RestTemplate restTemplate, ObjectMapper objectMapper) {
+
+    this.introspector = introspector;
+    this.restTemplate = restTemplate;
+    this.objectMapper = objectMapper;
+  }
 
   @Override
   public Optional<String> introspectToken(String accessToken) {

--- a/esaco-app/src/main/java/it/infn/mw/esaco/web/TokenInfoController.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/web/TokenInfoController.java
@@ -1,6 +1,5 @@
 package it.infn.mw.esaco.web;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,8 +14,12 @@ import it.infn.mw.esaco.service.TokenInfoService;
 @RestController
 public class TokenInfoController extends TokenControllerUtils {
 
-  @Autowired
   private TokenInfoService tokenInfoService;
+
+  public TokenInfoController(TokenInfoService tokenInfoService) {
+
+    this.tokenInfoService = tokenInfoService;
+  }
 
   @PostMapping(value = "/tokeninfo", produces = MediaType.APPLICATION_JSON_VALUE)
   public TokenInfo getUserInfo(@RequestParam(name = "token", required = false) String accessToken) {

--- a/esaco-app/src/main/java/it/infn/mw/esaco/web/TokenIntrospectionController.java
+++ b/esaco-app/src/main/java/it/infn/mw/esaco/web/TokenIntrospectionController.java
@@ -1,6 +1,5 @@
 package it.infn.mw.esaco.web;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -11,8 +10,12 @@ import it.infn.mw.esaco.service.TokenIntrospectionService;
 @RestController
 public class TokenIntrospectionController extends TokenControllerUtils {
 
-  @Autowired
   private TokenIntrospectionService tokenIntrospectionService;
+
+  public TokenIntrospectionController(TokenIntrospectionService tokenIntrospectionService) {
+
+    this.tokenIntrospectionService = tokenIntrospectionService;
+  }
 
   @PostMapping(value = "/introspect",
     produces = MediaType.APPLICATION_JSON_VALUE)

--- a/esaco-app/src/test/java/it/infn/mw/esaco/test/config/DelegatingOpaqueTokenIntrospectorTest.java
+++ b/esaco-app/src/test/java/it/infn/mw/esaco/test/config/DelegatingOpaqueTokenIntrospectorTest.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -27,7 +25,6 @@ import org.springframework.web.client.RestTemplate;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.KeyLengthException;
 import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -39,11 +36,11 @@ import it.infn.mw.esaco.exception.UnsupportedIssuerException;
 
 class DelegatingOpaqueTokenIntrospectorTest {
 
-  public final static String OIDC_DISCOVERY_URL =
+  public static final String OIDC_DISCOVERY_URL =
       "https://issuer.example.org/.well-known/openid-configuration";
-  public final static String OAUTH_DISCOVERY_URL =
+  public static final String OAUTH_DISCOVERY_URL =
       "https://issuer.example.org/.well-known/oauth-authorization-server";
-  public final static String UNTRUSTED_ISSUER = "https://unknown-issuer.example.org";
+  public static final String UNTRUSTED_ISSUER = "https://unknown-issuer.example.org";
 
   private OidcClientProperties properties;
   private OidcClient client;
@@ -88,8 +85,7 @@ class DelegatingOpaqueTokenIntrospectorTest {
         });
   }
 
-  private String createFakeJwtWithIssuer(String issuer)
-      throws ParseException, KeyLengthException, JOSEException {
+  private String createFakeJwtWithIssuer(String issuer) throws JOSEException {
 
     JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer(issuer).subject("sub").build();
     SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);

--- a/esaco-app/src/test/java/it/infn/mw/esaco/test/config/DelegatingOpaqueTokenIntrospectorTest.java
+++ b/esaco-app/src/test/java/it/infn/mw/esaco/test/config/DelegatingOpaqueTokenIntrospectorTest.java
@@ -1,0 +1,150 @@
+package it.infn.mw.esaco.test.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import it.infn.mw.esaco.OidcClient;
+import it.infn.mw.esaco.OidcClientProperties;
+import it.infn.mw.esaco.config.DelegatingOpaqueTokenIntrospector;
+import it.infn.mw.esaco.exception.UnsupportedIssuerException;
+
+public class DelegatingOpaqueTokenIntrospectorTest {
+
+  final String OIDC_DISCOVERY_URL = "https://issuer.example.org/.well-known/openid-configuration";
+  final String OAUTH_DISCOVERY_URL =
+      "https://issuer.example.org/.well-known/oauth-authorization-server";
+  final String UNTRUSTED_ISSUER = "https://unknown-issuer.example.org";
+
+  private OidcClientProperties properties;
+  private OidcClient client;
+  private RestTemplate restTemplate;
+  private Function<OidcClient, RestTemplate> restTemplateFactory;
+  private DelegatingOpaqueTokenIntrospector delegatingIntrospector;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+
+    client = new OidcClient();
+    client.setIssuerUrl("https://issuer.example.org");
+    client.setClientId("client-id");
+    client.setClientSecret("client-secret");
+
+    properties = new OidcClientProperties();
+    properties.getClients().add(client);
+
+    restTemplate = mock(RestTemplate.class);
+    restTemplateFactory = (Function<OidcClient, RestTemplate>) mock(Function.class);
+    when(restTemplateFactory.apply(client)).thenReturn(restTemplate);
+
+    delegatingIntrospector = new DelegatingOpaqueTokenIntrospector(properties, restTemplateFactory);
+  }
+
+  private void addDiscoveryResponse(String discoveryResponse, String discoveryUrl,
+      HttpStatus statusResponse) {
+
+    when(restTemplate.getForEntity(eq(discoveryUrl), eq(String.class)))
+      .thenReturn(new ResponseEntity<>(discoveryResponse, statusResponse));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void addIntrospectResponse(boolean isActive, HttpStatus responseStatus) {
+
+    when(restTemplate.exchange(Mockito.any(RequestEntity.class),
+        Mockito.any(ParameterizedTypeReference.class))).thenAnswer(invocation -> {
+          Map<String, Object> body = new HashMap<>();
+          body.put("active", isActive);
+          return new ResponseEntity<>(body, responseStatus);
+        });
+  }
+
+  private String createFakeJwtWithIssuer(String issuer) throws ParseException {
+    try {
+      JWTClaimsSet claims = new JWTClaimsSet.Builder().issuer(issuer).subject("sub").build();
+      SignedJWT jwt = new SignedJWT(
+          new com.nimbusds.jose.JWSHeader(com.nimbusds.jose.JWSAlgorithm.HS256), claims);
+      jwt.sign(new com.nimbusds.jose.crypto.MACSigner("12345678901234567890123456789012"));
+      return jwt.serialize();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Test
+  void testIntrospectionEndpointIsDiscoveredFromWellKnownConfiguration() throws Exception {
+
+    String issuer = client.getIssuerUrl();
+    String introspectUrl = "https://issuer.example.org/oauth2/introspect";
+    String discoveryResponse =
+        "{\"issuer\":\"" + issuer + "\",\"introspection_endpoint\":\"" + introspectUrl + "\"}";
+
+    addDiscoveryResponse(discoveryResponse, OIDC_DISCOVERY_URL, HttpStatus.OK);
+    addIntrospectResponse(true, HttpStatus.OK);
+
+    String token = createFakeJwtWithIssuer(issuer);
+    delegatingIntrospector.introspect(token);
+
+    // Assert discovery was performed with correct URL
+    verify(restTemplate).getForEntity(eq(OIDC_DISCOVERY_URL), eq(String.class));
+
+    ArgumentCaptor<RequestEntity> requestCaptor = ArgumentCaptor.forClass(RequestEntity.class);
+    // Assert introspection was performed with correct URL
+    verify(restTemplate).exchange(requestCaptor.capture(),
+        Mockito.any(ParameterizedTypeReference.class));
+
+    RequestEntity<?> capturedRequest = requestCaptor.getValue();
+    assertNotNull(capturedRequest);
+    assertEquals(introspectUrl, capturedRequest.getUrl().toString(),
+        "SpringOpaqueTokenIntrospector should call the discovered introspection endpoint URL");
+  }
+
+  @Test
+  void testUnsupportedIssuerThrowsException() throws Exception {
+
+    String token = createFakeJwtWithIssuer(UNTRUSTED_ISSUER);
+
+    UnsupportedIssuerException ex = assertThrows(UnsupportedIssuerException.class,
+        () -> delegatingIntrospector.introspect(token));
+
+    assertTrue(ex.getMessage().contains(UNTRUSTED_ISSUER));
+  }
+
+  @Test
+  void testDiscoveryFailsWhenNoIntrospectionEndpoint() throws Exception {
+
+    String issuer = client.getIssuerUrl();
+    String discoveryResponseWithNoIntrospect = "{\"issuer\":\"" + issuer + "\"}";
+
+    addDiscoveryResponse(discoveryResponseWithNoIntrospect, OIDC_DISCOVERY_URL, HttpStatus.OK);
+    addDiscoveryResponse(discoveryResponseWithNoIntrospect, OAUTH_DISCOVERY_URL, HttpStatus.OK);
+
+    String token = createFakeJwtWithIssuer(issuer);
+
+    assertThrows(IllegalStateException.class, () -> delegatingIntrospector.introspect(token));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,15 @@
     <spring-boot.version>3.5.7</spring-boot.version>
     <jib-maven-plugin.version>3.1.4</jib-maven-plugin.version>
     <nimbus.version>10.4</nimbus.version>
+
+    <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
+    <code.coverage.project.folder>${basedir}/../</code.coverage.project.folder>
+    <code.coverage.overall.data.folder>${basedir}/target/</code.coverage.overall.data.folder>
+
+    <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+    <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
+    <sonar.language>java</sonar.language>
+
   </properties>
 
   <parent>
@@ -138,6 +147,26 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>jacoco-initialize</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This PR also introduce the generation of the coverage report using Jacoco maven plugin, pushed to Sonarcloud.io.